### PR TITLE
Use semver in tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,10 +8,7 @@ builds:
     binary: bin/{{ .ProjectName }}
     goos:
       - darwin
-      - freebsd
       - linux
-      - netbsd
-      - solaris
       - windows
     goarch:
       - amd64
@@ -24,13 +21,12 @@ builds:
       - 7
 
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Tag }}_sha512-checksums.txt"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_sha512-checksums.txt"
   algorithm: sha512
 
 archives:
   - id: tar
     format: tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
- Remove unsupported GOOS in Bonsai
- Use the semver version (without `v` prefix) 