### PR TITLE
Add Github user to runtime asset definition for handler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the plugin with goreleaser. Register the asset with [Bonsai][8] to share it with
 - [Usage examples](#usage-examples)
 - [Configuration](#configuration)
   - [Asset registration](#asset-registration)
-  - [Resource definition](#resource-definition)
+  - [Handler definition](#handler-definition)
 - [Installation from source](#installation-from-source)
 - [Additional notes](#additional-notes)
 - [Contributing](#contributing)
@@ -66,7 +66,7 @@ sensuctl asset add {{ .GithubUser }}/{{ .GithubProject }}
 
 If you're using an earlier version of sensuctl, you can find the asset on the [Bonsai Asset Index][https://bonsai.sensu.io/assets/{{ .GithubUser }}/{{ .GithubProject }}].
 
-### Resource definition
+### Handler definition
 
 ```yml
 ---

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ spec:
   command: {{ .GithubProject }} --example example_arg
   type: pipe
   runtime_assets:
-  - {{ .GithubProject }}
+  - {{ .GithubUser}}/{{ .GithubProject }}
 ```
 
 ## Installation from source


### PR DESCRIPTION
Add Github user to runtime asset definition for handler example to match what sensuctl add asset would have added it as

Signed-off-by: Todd Campbell <todd@sensu.io>